### PR TITLE
export_model: remove exporting of yolo-nas

### DIFF
--- a/scripts/export_model.sh
+++ b/scripts/export_model.sh
@@ -75,8 +75,4 @@ qai-hub configure --api_token "$API_TOKEN"
 echo "Exporting YOLOv8 quantized model..."
 python -m qai_hub_models.models.yolov8_det.export --quantize w8a8 --skip-profiling --skip-inferencing
 
-echo "Exporting YOLO-NAS quantized model..."
-pip install "qai-hub-models[yolonas]"
-python -m qai_hub_models.models.yolonas.export --quantize w8a8 --skip-profiling --skip-inferencing
-
 echo "Miniconda installation, activation, Python 3.10 environment creation, and qai_hub package installation complete."


### PR DESCRIPTION
YOLO-NAS was removed as part of the ai-hub-models v0.27 release, as described at https://github.com/quic/ai-hub-models/releases/tag/v0.27.