### PR TITLE
build: fix include path for gst-sample-apps-utils dependents

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -104,7 +104,7 @@ function qimsdk-cmake-configure() {
 
     (
         export CFLAGS="-mbranch-protection=standard -fstack-protector-strong -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -pipe"
-        export CXXFLAGS="${CFLAGS}"
+        export CXXFLAGS="${CFLAGS} ${EXTRA_CXXFLAGS:-}"
 
         local CMAKE_FLAGS=(
             "-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"
@@ -147,8 +147,9 @@ function qimsdk-cmake-install() {
 function qimsdk-cmake-build() {
     local SOURCE_PATH="${1}"
     local TARGET=$(basename "${SOURCE_PATH}")
+    shift 1
 
-    qimsdk-cmake-configure "${SOURCE_PATH}" "${TARGET}" && \
+    qimsdk-cmake-configure "${SOURCE_PATH}" "${TARGET}" "$@" && \
     qimsdk-cmake-compile "${TARGET}" && \
     qimsdk-cmake-install "${TARGET}" && \
     qimsdk-print-build-success "${TARGET}"
@@ -187,21 +188,22 @@ function qimsdk-build-sample-apps() {
         1)
             # Build C Sample Apps from the array
             for APP in "${SAMPLE_APPS[@]}"; do
+                if [ "${APP}" = "gst-sample-apps-utils" ]; then
                 qimsdk-cmake-build "${REPO_PATH}/gst-sample-apps/${APP}" || return 1
 
-                    if [ "${APP}" = "gst-sample-apps-utils" ]; then
-                        mkdir -p "${SYSROOT_INCDIR}" "${SYSROOT_LIBDIR}" || return 1
+                mkdir -p "${SYSROOT_INCDIR}" "${SYSROOT_LIBDIR}" || return 1
 
-                        cp -vf \
-                            "${INSTALL_INCDIR}/gst_sample_apps_utils.h" \
-                            "${SYSROOT_INCDIR}/" || return 1
+                cp -vf \
+                    "${INSTALL_INCDIR}/gst_sample_apps_utils.h" \
+                    "${SYSROOT_INCDIR}/" || return 1
 
-                        cp -av \
-                            "${INSTALL_LIBDIR}/libgstappsutils.so"* \
-                            "${SYSROOT_LIBDIR}/" || return 1
-                        
-                    fi
-
+                cp -av \
+                    "${INSTALL_LIBDIR}/libgstappsutils.so"* \
+                    "${SYSROOT_LIBDIR}/" || return 1
+                else
+                    EXTRA_CXXFLAGS="-I${SYSROOT_INCDIR}" \
+                        qimsdk-cmake-build "${REPO_PATH}/gst-sample-apps/${APP}" || return 1
+                fi
             done
 
             echo "============================================================"


### PR DESCRIPTION
Fix this by:
- Forwarding extra cmake flags through qimsdk-cmake-build via shift+$@
- Appending EXTRA_CXXFLAGS to CXXFLAGS in qimsdk-cmake-configure to
  avoid the env var being overridden
- Passing -I<sysroot>/usr/include/gstreamer-1.0/gst/sampleapps to
  dependent apps after gst-sample-apps-utils is built and staged
